### PR TITLE
Fix quoting nil

### DIFF
--- a/lib/activerecord-mysql-awesome/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-awesome/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -133,6 +133,7 @@ module ActiveRecord
       end
 
       def quote(value, column = nil)
+        return super if value.nil?
         return super unless column && /time/ === column.sql_type
 
         if value.acts_like?(:time)


### PR DESCRIPTION
If `quote` is called with `nil` value, it raises ArgumentError for calling `nil.to_s(:db)`.

Below is head of backtraces.

```
/Users/a2ikm/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/activerecord-mysql-awesome-0.0.5/lib/activerecord-mysql-awesome/active_record/connection_adapters/abstract_mysql_adapter.rb:152:in `to_s': wrong number of arguments (1 for 0) (ArgumentError)
	from /Users/a2ikm/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/activerecord-mysql-awesome-0.0.5/lib/activerecord-mysql-awesome/active_record/connection_adapters/abstract_mysql_adapter.rb:152:in `quote'
```