### PR TITLE
fix supports_datetime_with_precision

### DIFF
--- a/lib/activerecord-mysql-awesome/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-awesome/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -209,7 +209,8 @@ module ActiveRecord
       public
 
       def supports_datetime_with_precision?
-        (version[0] == 5 && version[1] >= 6) || version[0] >= 6
+        version_array = version.instance_variable_get(:@version)
+        (version_array[0] == 5 && version_array[1] >= 6) || version_array[0] >= 6
       end
 
       def type_to_sql(type, limit = nil, precision = nil, scale = nil, unsigned = false)

--- a/test/cases/helper.rb
+++ b/test/cases/helper.rb
@@ -40,7 +40,7 @@ end
 
 def mysql_56?
   current_adapter?(:Mysql2Adapter) &&
-    ActiveRecord::Base.connection.send(:version).join(".") >= "5.6.0"
+    ActiveRecord::Base.connection.send(:version).instance_variable_get(:@version).join(".") >= "5.6.0"
 end
 
 # FIXME: we have tests that depend on run order, we should fix that and


### PR DESCRIPTION
Since ActiveRecord 4.2.7's `ActiveRecord::Base.connection.version` returns a instance of `ActiveRecord::ConnectionAdapters::AbstractAdapter::Version`, `supports_datetime_with_precision?` now raises this error.
```
NoMethodError: undefined method []' for #<ActiveRecord::ConnectionAdapters::AbstractAdapter::Version>
```

So I fixed it, How is this?