### PR TITLE
Support ActiveRecord 4.2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem "activerecord", "~> #{ENV['AR_VERSION']}" if ENV['AR_VERSION']
+gem "mysql2", "~> 0.3.18"
 
 # Specify your gem's dependencies in activerecord-mysql-awesome.gemspec
 gemspec

--- a/lib/activerecord-mysql-awesome/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-awesome/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -208,26 +208,6 @@ module ActiveRecord
 
       public
 
-      class Version
-        include Comparable
-
-        def initialize(version_string)
-          @version = version_string.split('.').map(&:to_i)
-        end
-
-        def <=>(version_string)
-          @version <=> version_string.split('.').map(&:to_i)
-        end
-
-        def [](index)
-          @version[index]
-        end
-      end
-
-      def version
-        @version ||= Version.new(full_version.match(/^\d+\.\d+\.\d+/)[0])
-      end
-
       def supports_datetime_with_precision?
         version >= '5.6.4'
       end

--- a/lib/activerecord-mysql-awesome/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-awesome/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -208,8 +208,28 @@ module ActiveRecord
 
       public
 
+      class Version
+        include Comparable
+
+        def initialize(version_string)
+          @version = version_string.split('.').map(&:to_i)
+        end
+
+        def <=>(version_string)
+          @version <=> version_string.split('.').map(&:to_i)
+        end
+
+        def [](index)
+          @version[index]
+        end
+      end
+
+      def version
+        @version ||= Version.new(full_version.match(/^\d+\.\d+\.\d+/)[0])
+      end
+
       def supports_datetime_with_precision?
-        (version[0] == 5 && version[1] >= 6) || version[0] >= 6
+        version >= '5.6.4'
       end
 
       def type_to_sql(type, limit = nil, precision = nil, scale = nil, unsigned = false)

--- a/lib/activerecord-mysql-awesome/active_record/connection_adapters/mysql2_adapter.rb
+++ b/lib/activerecord-mysql-awesome/active_record/connection_adapters/mysql2_adapter.rb
@@ -1,0 +1,27 @@
+require 'active_record/connection_adapters/mysql2_adapter'
+
+module ActiveRecord
+  module ConnectionAdapters
+    class Mysql2Adapter < AbstractMysqlAdapter
+      class Version
+        include Comparable
+
+        def initialize(version_string)
+          @version = version_string.split('.').map(&:to_i)
+        end
+
+        def <=>(version_string)
+          @version <=> version_string.split('.').map(&:to_i)
+        end
+
+        def [](index)
+          @version[index]
+        end
+      end
+
+      def version
+        @version ||= Version.new(@connection.server_info[:version].match(/^\d+\.\d+\.\d+/)[0])
+      end
+    end
+  end
+end

--- a/lib/activerecord/mysql/awesome/base.rb
+++ b/lib/activerecord/mysql/awesome/base.rb
@@ -2,6 +2,7 @@ if ActiveRecord::VERSION::MAJOR == 4
   require 'activerecord-mysql-awesome/active_record/schema_dumper'
   require 'activerecord-mysql-awesome/active_record/connection_adapters/abstract/schema_dumper'
   require 'activerecord-mysql-awesome/active_record/connection_adapters/abstract_mysql_adapter'
+  require 'activerecord-mysql-awesome/active_record/connection_adapters/mysql2_adapter'
 else
   raise "activerecord-mysql-awesome supports activerecord ~> 4.x"
 end

--- a/test/cases/date_time_precision_test.rb
+++ b/test/cases/date_time_precision_test.rb
@@ -83,7 +83,7 @@ class DateTimePrecisionTest < ActiveRecord::TestCase
   def test_datetime_column_with_default_in_string_works
     @connection.create_table(:foos, force: true)
     @connection.add_column :foos, :default_at, :datetime, default: "2015-01-02 03:04:05"
-    assert_equal "2015-01-02 03:04:05", activerecord_column_option('foos', 'default_at', 'default')
+    assert_match %r{2015-01-02 03:04:05}, activerecord_column_option('foos', 'default_at', 'default').to_s
   end
 
   private

--- a/test/cases/helper.rb
+++ b/test/cases/helper.rb
@@ -39,8 +39,7 @@ def current_adapter?(*types)
 end
 
 def mysql_56?
-  current_adapter?(:Mysql2Adapter) &&
-    ActiveRecord::Base.connection.send(:version).join(".") >= "5.6.0"
+  current_adapter?(:Mysql2Adapter) && ActiveRecord::Base.connection.version >= "5.6.0"
 end
 
 # FIXME: we have tests that depend on run order, we should fix that and


### PR DESCRIPTION
The return value of `version` was changed by backported
rails/rails@4b5570b.
This commit makes to support both `version` behavior.

Fixes #7.