### PR TITLE
Add background information README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Awesome patches backported for ActiveRecord MySQL adapters.
 
+Contains numerous patches backported from Rails 5 for use in Rails 4.x applications.
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -22,7 +24,16 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+Just install it.
+
+Patches from the following Rails pull requests are included:
+
+* [Add SchemaDumper support table_options for MySQL. #17569](https://github.com/rails/rails/pull/17569)
+* [Add charset and collation options support for MySQL string and text columns. #17574](https://github.com/rails/rails/pull/17574)
+* [Add bigint pk support for MySQL #17631](https://github.com/rails/rails/pull/17631)
+* [If do not specify strict_mode explicitly, do not set sql_mode. #17654](https://github.com/rails/rails/pull/17654)
+* [Add unsigned option support for MySQL numeric data types #17696](https://github.com/rails/rails/pull/17696)
+* [Support for any type primary key #17851](https://github.com/rails/rails/pull/17851)
 
 ## Contributing
 


### PR DESCRIPTION
Explain that this gem is only useful for Rails 4.x applications.

List of patches taken from http://qiita.com/kamipo/items/11b55caf329210923a9a
