### PR TITLE
Enable JRuby support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem "activerecord", "~> #{ENV['AR_VERSION']}" if ENV['AR_VERSION']
-gem "mysql2", "~> 0.3.18"
+gem "mysql2", "~> 0.3.18", :platform => :mri
 
 # Specify your gem's dependencies in activerecord-mysql-awesome.gemspec
 gemspec

--- a/activerecord-mysql-awesome.gemspec
+++ b/activerecord-mysql-awesome.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_runtime_dependency "activesupport", "~> 4.0"
   spec.add_runtime_dependency "activerecord", "~> 4.0"
-  spec.add_runtime_dependency "mysql2", ">= 0.3.18"
+  spec.add_runtime_dependency "mysql2", ">= 0.3.18" unless RUBY_PLATFORM == 'java'
 end

--- a/lib/activerecord-mysql-awesome/active_record/connection_adapters/mysql2_adapter.rb
+++ b/lib/activerecord-mysql-awesome/active_record/connection_adapters/mysql2_adapter.rb
@@ -1,26 +1,28 @@
-require 'active_record/connection_adapters/mysql2_adapter'
+unless RUBY_PLATFORM == 'java'
+  require 'active_record/connection_adapters/mysql2_adapter'
 
-module ActiveRecord
-  module ConnectionAdapters
-    class Mysql2Adapter < AbstractMysqlAdapter
-      class Version
-        include Comparable
+  module ActiveRecord
+    module ConnectionAdapters
+      class Mysql2Adapter < AbstractMysqlAdapter
+        class Version
+          include Comparable
 
-        def initialize(version_string)
-          @version = version_string.split('.').map(&:to_i)
+          def initialize(version_string)
+            @version = version_string.split('.').map(&:to_i)
+          end
+
+          def <=>(version_string)
+            @version <=> version_string.split('.').map(&:to_i)
+          end
+
+          def [](index)
+            @version[index]
+          end
         end
 
-        def <=>(version_string)
-          @version <=> version_string.split('.').map(&:to_i)
+        def version
+          @version ||= Version.new(@connection.server_info[:version].match(/^\d+\.\d+\.\d+/)[0])
         end
-
-        def [](index)
-          @version[index]
-        end
-      end
-
-      def version
-        @version ||= Version.new(@connection.server_info[:version].match(/^\d+\.\d+\.\d+/)[0])
       end
     end
   end


### PR DESCRIPTION
Requiring the mysql2 gem makes it impossible
to run these useful patches without running mri.

We would like to introduce this library to a JRuby
project, and so the goal is to make it possible to
skip including mysql2 as a dependency in cases where
we can detect a Java runtime.